### PR TITLE
fix na nowe domyślne zachowanie nowych s3

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -20,9 +20,31 @@ resource "aws_s3_bucket_policy" "b" {
 EOF
 }
 
+resource "aws_s3_bucket_ownership_controls" "b" {
+  bucket = aws_s3_bucket.b.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "b" {
+  bucket = aws_s3_bucket.b.id
+
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = false
+}
+
+
 resource "aws_s3_bucket_acl" "b" {
   bucket = aws_s3_bucket.b.bucket
   acl = "public-read"
+
+  depends_on = [
+    aws_s3_bucket_ownership_controls.b,
+    aws_s3_bucket_public_access_block.b,
+  ]
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "b" {

--- a/main.tf
+++ b/main.tf
@@ -39,6 +39,10 @@ resource "aws_s3_bucket_public_access_block" "b" {
   block_public_policy     = false
   ignore_public_acls      = false
   restrict_public_buckets = false
+
+  depends_on = [
+    aws_s3_bucket_ownership_controls.b,
+  ]
 }
 
 

--- a/main.tf
+++ b/main.tf
@@ -4,6 +4,11 @@ resource "aws_s3_bucket" "b" {
 }
 
 resource "aws_s3_bucket_policy" "b" {
+  depends_on = [
+    aws_s3_bucket_ownership_controls.b,
+    aws_s3_bucket_public_access_block.b,
+  ]
+
   bucket = aws_s3_bucket.b.bucket
   policy = <<EOF
 {

--- a/redirect_dist.tf
+++ b/redirect_dist.tf
@@ -6,6 +6,11 @@ resource "aws_s3_bucket" "redirect" {
 
 resource "aws_s3_bucket_policy" "redirect" {
   count = var.create_redirect ? 1 : 0
+  depends_on = [
+    aws_s3_bucket_ownership_controls.redirect,
+    aws_s3_bucket_public_access_block.redirect,
+  ]
+
   bucket = aws_s3_bucket.redirect[count.index].bucket
   policy = <<EOF
 {
@@ -26,7 +31,35 @@ resource "aws_s3_bucket_acl" "redirect" {
   count = var.create_redirect ? 1 : 0
   bucket = aws_s3_bucket.redirect[count.index].bucket
   acl = "public-read"
+
+  depends_on = [
+    aws_s3_bucket_ownership_controls.redirect,
+    aws_s3_bucket_public_access_block.redirect,
+  ]
 }
+
+resource "aws_s3_bucket_ownership_controls" "redirect" {
+  count = var.create_redirect ? 1 : 0
+  bucket = aws_s3_bucket.redirect[count.index].id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "redirect" {
+  count = var.create_redirect ? 1 : 0
+  bucket = aws_s3_bucket.redirect[count.index].id
+
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = false
+
+  depends_on = [
+    aws_s3_bucket_ownership_controls.redirect,
+  ]
+}
+
 
 resource "aws_s3_bucket_lifecycle_configuration" "redirect" {
   count = var.create_redirect ? 1 : 0


### PR DESCRIPTION
Ogłoszenie od AWS
https://aws.amazon.com/about-aws/whats-new/2022/12/amazon-s3-automatically-enable-block-public-access-disable-access-control-lists-buckets-april-2023/

Uwzględniłem także zależności między zasobami – bez nich po prostu się wywala
https://github.com/hashicorp/terraform-provider-aws/issues/30951#issuecomment-1523376909